### PR TITLE
PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,25 +10,40 @@ matrix:
   fast_finish: true
   include:
     - env:
-      - VERSION=7.1
+      - VERSION=7.2
       - ALIAS=latest
     - env:
-      - VERSION=7.1
+      - VERSION=7.2
       - VARIANT=fpm
       - ALIAS=fpm
     - env:
-      - VERSION=7.1
+      - VERSION=7.2
       - VARIANT=apache
       - ALIAS=apache
     - env:
-      - VERSION=7.1
+      - VERSION=7.2
       - BASE=alpine
       - ALIAS=alpine
+    - env:
+      - VERSION=7.2
+      - VARIANT=fpm
+      - BASE=alpine
+      - ALIAS=fpm-alpine
+    - env:
+      - VERSION=7.1
+    - env:
+      - VERSION=7.1
+      - VARIANT=fpm
+    - env:
+      - VERSION=7.1
+      - VARIANT=apache
+    - env:
+      - VERSION=7.1
+      - BASE=alpine
     - env:
       - VERSION=7.1
       - VARIANT=fpm
       - BASE=alpine
-      - ALIAS=fpm-alpine
 
 script:
   - ./build

--- a/7.1.Dockerfile
+++ b/7.1.Dockerfile
@@ -1,0 +1,2 @@
+ENV PHP_ADDITIONAL_EXTENSIONS \
+    mcrypt

--- a/base-alpine.Dockerfile
+++ b/base-alpine.Dockerfile
@@ -41,7 +41,7 @@ RUN set -xe \
     && pecl install --force ${PECL_PACKAGES} \
     && configure \
     && apk del .phpize-deps-configure \
-    && docker-php-ext-install -j$(getconf _NPROCESSORS_ONLN) ${PHP_EXTENSIONS} \
+    && docker-php-ext-install -j$(getconf _NPROCESSORS_ONLN) ${PHP_EXTENSIONS} ${PHP_ADDITIONAL_EXTENSIONS} \
     && apk del .build-deps
 
 # Yarn setup

--- a/base-debian.Dockerfile
+++ b/base-debian.Dockerfile
@@ -6,7 +6,7 @@ libicu-dev \
 zlib1g-dev \
 libfreetype6-dev \
 libjpeg62-turbo-dev \
-libpng12-dev \
+libpng-dev \
 libgif-dev \
 libxpm-dev \
 libvpx-dev \
@@ -20,7 +20,7 @@ libicu-dev \
 
 # Special NodeJS apt setup (Use LTS version)
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
-&& apt-get install nodejs \
+&& apt-get install nodejs --yes \
 && rm --recursive --force /var/lib/apt/lists/*
 
 # Special Yarn apt setup
@@ -47,4 +47,4 @@ RUN configure
 
 # Extensions
 # https://github.com/docker-library/docs/blob/master/php/content.md#how-to-install-more-php-extensions
-RUN docker-php-ext-install -j`nproc` ${PHP_EXTENSIONS}
+RUN docker-php-ext-install -j`nproc` ${PHP_EXTENSIONS} ${PHP_ADDITIONAL_EXTENSIONS}

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -22,7 +22,6 @@ ENV PHP_EXTENSIONS \
     shmop \
     mbstring \
     exif \
-    mcrypt \
     imap \
     soap
 

--- a/build
+++ b/build
@@ -26,6 +26,10 @@ rm --recursive --force ${BUILD_DIR} && mkdir --parent ${BUILD_DIR}
 # Creates the final Dockerfile
 cp ./base.Dockerfile ${BUILD_DIR}/Dockerfile
 echo >> ${BUILD_DIR}/Dockerfile
+if [ -f ${VERSION}.Dockerfile ]; then
+    cat ${VERSION}.Dockerfile >> ${BUILD_DIR}/Dockerfile
+    echo >> ${BUILD_DIR}/Dockerfile
+fi
 cat base-${_base}.Dockerfile >> ${BUILD_DIR}/Dockerfile
 echo >> ${BUILD_DIR}/Dockerfile
 cat ${_variant}.Dockerfile >> ${BUILD_DIR}/Dockerfile
@@ -46,3 +50,4 @@ if [ ! -z "${ALIAS}" ]; then
 fi
 
 docker run --rm -v `pwd`:`pwd` -w `pwd` nexylan/php-dev:${tag} php --version
+docker run --rm -v `pwd`:`pwd` -w `pwd` nexylan/php-dev:${tag} php -m


### PR DESCRIPTION
Replace #11 

- [x] `mcrypt` is removed from PHP 7.2. Conditional install is needed. https://github.com/docker-library/php/issues/541