### PR TITLE
Exclude slevomat/coding-standard 4.8.0

### DIFF
--- a/cli.Dockerfile
+++ b/cli.Dockerfile
@@ -14,7 +14,7 @@ dealerdirect/phpcodesniffer-composer-installer \
 doctrine/coding-standard \
 escapestudios/symfony2-coding-standard \
 object-calisthenics/phpcs-calisthenics-rules \
-slevomat/coding-standard \
+slevomat/coding-standard:!=4.8.0 \
 wimg/php-compatibility \
 && composer clear-cache
 


### PR DESCRIPTION
Related to https://github.com/slevomat/coding-standard/issues/486