### PR TITLE
Add shellcheck compilation for alpine, and classic installation for debian

### DIFF
--- a/base-alpine.Dockerfile
+++ b/base-alpine.Dockerfile
@@ -51,3 +51,12 @@ RUN cd /opt \
     && tar xzf yarn.tar.gz -C yarn --strip-components 1 \
     && cd /usr/local/bin \
     && ln -s /opt/yarn/bin/yarn
+
+# Shellcheck setup
+ADD https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.x86_64.tar.xz /opt/shellcheck.tar.xz
+RUN cd /opt \
+	&& mkdir shellcheck \
+	&& tar --xz --extract --file shellcheck.tar.xz --directory shellcheck \
+	&& cp shellcheck/shellcheck-stable/shellcheck /usr/bin/ \
+	&& shellcheck --version \
+	&& rm -rf shellcheck shellcheck.tar.xz

--- a/base-debian.Dockerfile
+++ b/base-debian.Dockerfile
@@ -16,6 +16,8 @@ libc-client-dev \
 libkrb5-dev \
 libxml2-dev \
 libicu-dev \
+shellcheck \
+
 && rm --recursive --force /var/lib/apt/lists/*
 
 # Special NodeJS apt setup (Use LTS version)


### PR DESCRIPTION
Fixes #17

Added shellcheck by compilation for alpine and classical install (apt) for debian.