### PR TITLE
Install Docker to allow images build

### DIFF
--- a/base-alpine.Dockerfile
+++ b/base-alpine.Dockerfile
@@ -51,3 +51,7 @@ RUN cd /opt \
     && tar xzf yarn.tar.gz -C yarn --strip-components 1 \
     && cd /usr/local/bin \
     && ln -s /opt/yarn/bin/yarn
+
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/latest-stable/community" >> /etc/apk/repositories; \
+    && apk update \
+    && apk add docker

--- a/base-debian.Dockerfile
+++ b/base-debian.Dockerfile
@@ -49,3 +49,18 @@ RUN configure
 # Extensions
 # https://github.com/docker-library/docs/blob/master/php/content.md#how-to-install-more-php-extensions
 RUN docker-php-ext-install -j`nproc` ${PHP_EXTENSIONS} ${PHP_ADDITIONAL_EXTENSIONS}
+
+RUN apt-get update \
+&& apt-get install --yes \
+apt-transport-https \
+ca-certificates \
+curl \
+gnupg2 \
+software-properties-common \
+&& curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
+&& apt-key fingerprint 0EBFCD88 \
+&& add-apt-repository \
+"deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+&& apt-get update \
+&& apt-get install --yes docker-ce \
+&& rm --recursive --force /var/lib/apt/lists/*


### PR DESCRIPTION
Install Docker to allow php-dev to build images and then push it on a registry